### PR TITLE
Update parent to latest confluen kafka-connect-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
+        <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-parent</artifactId>
-        <version>2.4.0</version>
+        <version>4.1.0</version>
     </parent>
     <groupId>com.themeetgroup.kafka.connect</groupId>
     <artifactId>kafka-connect-rabbitmq</artifactId>
@@ -54,6 +54,7 @@
 
     <properties>
         <rabbitmq.version>5.10.0</rabbitmq.version>
+        <mockito.version>3.3.0</mockito.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Use mockito 3.3.0 for compatibility with existing code (latest
  io.confluent uses 3.6.0)