### PR TITLE
Add Sink connector format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Kafka topic to write the messages to.
 
 *Type:* List
 
+##### `rabbitmq.queue.topic.mapping`
+*Importance:* High
+
+*Type:* List
+
+A list containing a mapping between a RabbitMQ queue and a Kafka topic.
+ This setting is an alternative for the 'rabbitmq.queue' and 'kafka.topic' setting. This allows to use a single connector instance to have a many-to-many mapping, instead of only a many queues to one topic mapping. 
+  When both settings are present. The 'rabbitmq.queue' and 'kafka.topic' will be used. Example of mapping config: 'queue1:topic1,queue2:topic2'
 
 rabbitmq.queue
 ##### `rabbitmq.host`

--- a/README.md
+++ b/README.md
@@ -262,6 +262,16 @@ exchange to publish the messages on.
 
 
 routing key used for publishing the messages.
+
+##### `rabbitmq.format`
+*Importance:* High
+
+*Type:* String
+
+*Default Value:* bytes
+
+The format type to use when writing data to RabbitMQ (currently supported values are bytes, json)
+
 ##### `topics`
 *Importance:* High
 

--- a/README.md
+++ b/README.md
@@ -63,15 +63,21 @@ The username to authenticate to RabbitMQ with. See `ConnectionFactory.setUsernam
 
 *Default Value:* /
 
-Converter to compose the Kafka message.
+The virtual host to use when connecting to the broker. See `ConnectionFactory.setVirtualHost(java.lang.String) <https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/ConnectionFactory.html#setVirtualHost-java.lang.String->`_
+
 ##### `message.converter`
 *Importance:* Medium
 
 *Type:* String
 
 *Default Value:* com.github.themeetgroup.kafka.connect.rabbitmq.source.data.MessageConverter
+*Other allowed values*: 
+- com.github.themeetgroup.kafka.connect.rabbitmq.source.data.BytesSourceMessageConverter
+- com.github.themeetgroup.kafka.connect.rabbitmq.source.data.StringSourceMessageConverter
 
-The virtual host to use when connecting to the broker. See `ConnectionFactory.setVirtualHost(java.lang.String) <https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/ConnectionFactory.html#setVirtualHost-java.lang.String->`_
+Converter to compose the Kafka message.
+
+
 ##### `rabbitmq.port`
 *Importance:* Medium
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The virtual host to use when connecting to the broker. See `ConnectionFactory.se
 *Type:* String
 
 *Default Value:* com.github.themeetgroup.kafka.connect.rabbitmq.source.data.MessageConverter
+
 *Other allowed values*: 
 - com.github.themeetgroup.kafka.connect.rabbitmq.source.data.BytesSourceMessageConverter
 - com.github.themeetgroup.kafka.connect.rabbitmq.source.data.StringSourceMessageConverter
@@ -270,7 +271,11 @@ routing key used for publishing the messages.
 
 *Default Value:* bytes
 
-The format type to use when writing data to RabbitMQ (currently supported values are bytes, json)
+*Other allowed values*: 
+- json
+- avro (non Confluent avro)
+
+The format type to use when writing data to RabbitMQ
 
 ##### `topics`
 *Importance:* High

--- a/bin/create-topic.sh
+++ b/bin/create-topic.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-kafka-topics --create --topic rabbitmq.test --bootstrap-server 127.0.0.1:9092
+kafka-topics --create --topic rabbitmq-test --bootstrap-server 127.0.0.1:9092

--- a/bin/create-topics.sh
+++ b/bin/create-topics.sh
@@ -15,4 +15,5 @@
 # limitations under the License.
 #
 
-kafka-topics --create --topic rabbitmq-test --bootstrap-server 127.0.0.1:9092
+kafka-topics --create --topic topic1 --bootstrap-server 127.0.0.1:9092
+kafka-topics --create --topic topic2 --bootstrap-server 127.0.0.1:9092

--- a/bin/debug.sh
+++ b/bin/debug.sh
@@ -21,5 +21,5 @@ export KAFKA_DEBUG='y'
 
 set -e
 
-mvn clean package
-connect-standalone config/connect-avro-docker.properties config/RabbitMQSinkConnector.properties
+mvn clean package -Dcheckstyle.skip
+connect-standalone config/connect-avro-docker.properties config/RabbitMQSourceConnector.properties

--- a/bin/debug.sh
+++ b/bin/debug.sh
@@ -22,4 +22,4 @@ export KAFKA_DEBUG='y'
 set -e
 
 mvn clean package
-connect-standalone config/connect-avro-docker.properties config/RabbitMQSourceConnector.properties
+connect-standalone config/connect-avro-docker.properties config/RabbitMQSinkConnector.properties

--- a/bin/read-topic-with-headers.sh
+++ b/bin/read-topic-with-headers.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-kafkacat -b localhost:9092 -t rabbitmq.test -C \
+kafkacat -b localhost:9092 -t topic1 -C \
   -f '\nKey (%K bytes): %k
   Value (%S bytes): %s
   Timestamp: %T

--- a/config/RabbitMQSinkConnector.properties
+++ b/config/RabbitMQSinkConnector.properties
@@ -1,0 +1,7 @@
+name=rabbitmq-sink
+tasks.max=1
+connector.class=com.github.themeetgroup.kafka.connect.rabbitmq.sink.RabbitMQSinkConnector
+rabbitmq.exchange=exchange
+rabbitmq.routing.key=routingkey
+rabbitmq.format=json
+topics=rabbitmq-test

--- a/config/RabbitMQSourceConnector.properties
+++ b/config/RabbitMQSourceConnector.properties
@@ -1,0 +1,6 @@
+name=rabbitmq-source
+tasks.max=1
+connector.class=com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnector
+rabbitmq.queue=test
+kafka.topic=rabbitmq-test
+message.converter=com.github.themeetgroup.kafka.connect.rabbitmq.source.data.BytesSourceMessageConverter

--- a/config/RabbitMQSourceConnector.properties
+++ b/config/RabbitMQSourceConnector.properties
@@ -1,6 +1,7 @@
 name=rabbitmq-source
 tasks.max=1
 connector.class=com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnector
-rabbitmq.queue=test
-kafka.topic=rabbitmq-test
+#rabbitmq.queue=test1,test2
+#kafka.topic=rabbitmq-test
+rabbitmq.queue.topic.mapping=test1:topic1,test2:topic2
 message.converter=com.github.themeetgroup.kafka.connect.rabbitmq.source.data.BytesSourceMessageConverter

--- a/config/connect-avro-docker.properties
+++ b/config/connect-avro-docker.properties
@@ -1,0 +1,6 @@
+bootstrap.servers=localhost:9092
+key.converter=org.apache.kafka.connect.storage.StringConverter
+value.converter=io.confluent.connect.avro.AvroConverter
+value.converter.schema.registry.url=http://localhost:8081
+offset.storage.file.filename=/tmp/connect.offsets
+plugin.path=target/kafka-connect-target/usr/share/kafka-connect 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,9 @@
         <mockito.version>3.3.0</mockito.version>
         <kafka.version>2.6.0</kafka.version>
         <confluent.version>6.0.0</confluent.version>
-        <!-- Keep this version in sync with version used in Kafka releases -->
+        <!-- Keep those versions in sync with version used in Kafka releases -->
         <jackson.version>2.8.5</jackson.version>
+        <avro.version>1.9.2</avro.version>
     </properties>
 
     <dependencies>
@@ -161,6 +162,28 @@
                             </tags>
                             <title>Kafka Connect RabbitMQ</title>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+                <configuration>
+                    <sourceDirectory>${project.basedir}/src/test/resources</sourceDirectory>
+                    <imports>
+                        <import>${project.basedir}/src/test/resources/payment.avsc</import>
+                    </imports>
+                    <enableDecimalLogicalType>true</enableDecimalLogicalType>
+                    <fieldVisibility>private</fieldVisibility>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>second</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,28 @@
         <rabbitmq.version>5.10.0</rabbitmq.version>
         <mockito.version>3.3.0</mockito.version>
         <kafka.version>2.6.0</kafka.version>
-        <confluent.version>6.0.1</confluent.version>
+        <confluent.version>6.0.0</confluent.version>
+        <!-- Keep this version in sync with version used in Kafka releases -->
+        <jackson.version>2.8.5</jackson.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <version>${rabbitmq.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
@@ -85,36 +103,6 @@
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.rabbitmq</groupId>
-            <artifactId>amqp-client</artifactId>
-            <version>${rabbitmq.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
-            <artifactId>connect-utils-testing-data</artifactId>
-            <version>${connect-utils.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>1.10.1</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,25 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>fat-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <source>8</source>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
         </license>
     </licenses>
 
+    <repositories>
+        <repository>
+            <id>Confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
     <developers>
         <developer>
             <id>jcustenborder</id>
@@ -32,9 +39,17 @@
             </roles>
         </developer>
         <developer>
-            <id>insidn</id>
+            <id>insidin</id>
             <name>Jan Uyttenhove</name>
             <url>https://github.com/insidin</url>
+            <roles>
+                <role>Committer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>jelledv</id>
+            <name>Jelle De Vleminck</name>
+            <url>https://github.com/jelledv</url>
             <roles>
                 <role>Committer</role>
             </roles>
@@ -55,9 +70,37 @@
     <properties>
         <rabbitmq.version>5.10.0</rabbitmq.version>
         <mockito.version>3.3.0</mockito.version>
+        <kafka.version>2.6.0</kafka.version>
+        <confluent.version>6.0.1</confluent.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
@@ -71,13 +114,9 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.8.2</version>
+            <version>1.10.1</version>
         </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>5.1.0</version>
-        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/RabbitMQSinkConnectorConfig.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/RabbitMQSinkConnectorConfig.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import com.github.jcustenborder.kafka.connect.utils.template.StructTemplate;
 
 public class RabbitMQSinkConnectorConfig extends CommonRabbitMQConnectorConfig {
+
   static final String KAFKA_TOPIC_TEMPLATE = "kafkaTopicTemplate";
   public static final String TOPIC_CONF = "topics";
   static final String TOPIC_DOC = "Kafka topic to read the messages from.";
@@ -36,14 +37,17 @@ public class RabbitMQSinkConnectorConfig extends CommonRabbitMQConnectorConfig {
   public static final String ROUTING_KEY_CONF = "rabbitmq.routing.key";
   static final String ROUTING_KEY_DOC = "routing key used for publishing the messages.";
 
+  public static final String FORMAT_CONF = "rabbitmq.format";
+  public static final String FORMAT_CONF_DOC = "The format type to use when writing data to rabbitMQ";
+  public static final String FORMAT_CONF_DEFAULT = "bytes";
 
   public static final String HEADER_CONF = "rabbitmq.headers";
   public static final String HEADER_CONF_DOC = "Headers to set for outbounf messages. Set with `headername1`:`headervalue1`,`headername2`:`headervalue2`";
-    //TODO: include other config variables here
 
   public final StructTemplate kafkaTopic;
   public final String exchange;
   public final String routingKey;
+  public final String format;
 
   public RabbitMQSinkConnectorConfig(Map<String, String> settings) {
     super(config(), settings);
@@ -52,16 +56,15 @@ public class RabbitMQSinkConnectorConfig extends CommonRabbitMQConnectorConfig {
     this.kafkaTopic.addTemplate(KAFKA_TOPIC_TEMPLATE, kafkaTopicFormat);
     this.exchange = this.getString(EXCHANGE_CONF);
     this.routingKey = this.getString(ROUTING_KEY_CONF);
+    this.format = this.getString(FORMAT_CONF);
   }
 
   public static ConfigDef config() {
     return CommonRabbitMQConnectorConfig.config()
-        .define(TOPIC_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TOPIC_DOC)
-        .define(EXCHANGE_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, EXCHANGE_DOC)
-        .define(ROUTING_KEY_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, ROUTING_KEY_DOC)
-        .define(HEADER_CONF, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.LOW, HEADER_CONF_DOC);
-
-
+            .define(TOPIC_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TOPIC_DOC)
+            .define(EXCHANGE_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.MEDIUM, EXCHANGE_DOC)
+            .define(ROUTING_KEY_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, ROUTING_KEY_DOC)
+            .define(FORMAT_CONF, ConfigDef.Type.STRING, FORMAT_CONF_DEFAULT, ConfigDef.Importance.HIGH, FORMAT_CONF_DOC)
+            .define(HEADER_CONF, ConfigDef.Type.STRING, null, null, ConfigDef.Importance.LOW, HEADER_CONF_DOC);
   }
-
 }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatter.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright © 2017 Kyumars Sheykh Esmaili (kyumarss@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import io.confluent.connect.avro.AvroData;
+import io.confluent.kafka.serializers.NonRecordContainer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class AvroFormatter implements RecordFormatter {
+
+  private final AvroData avroData;
+  private final EncoderFactory encoderFactory;
+
+  public AvroFormatter() {
+    avroData = new AvroData(10);
+    encoderFactory = EncoderFactory.get();
+  }
+
+  @Override
+  public byte[] format(SinkRecord sinkRecord) {
+    Schema avroSchema = avroData.fromConnectSchema(sinkRecord.valueSchema());
+    Object o = avroData.fromConnectData(sinkRecord.valueSchema(), sinkRecord.value());
+    if (o == null) {
+      return null;
+    }
+    return serialize(o, avroSchema);
+  }
+
+  private byte[] serialize(Object object, Schema schema) {
+    Object value = object instanceof NonRecordContainer ? ((NonRecordContainer) object).getValue() : object;
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      if (schema.getType() == Schema.Type.BYTES) {
+        if (value instanceof byte[]) {
+          out.write(((byte[]) value));
+        } else {
+          if (!(value instanceof ByteBuffer)) {
+            throw new DataException("Error serializing message to format Avro. Unrecognized bytes object of type: " + value.getClass().getName());
+          }
+          out.write(((ByteBuffer) value).array());
+        }
+      } else {
+        BinaryEncoder encoder = encoderFactory.directBinaryEncoder(out, null);
+        DatumWriter<Object> writer;
+        if (value instanceof SpecificRecord) {
+          writer = new SpecificDatumWriter<>(schema);
+        } else {
+          writer = new GenericDatumWriter<>(schema);
+        }
+        writer.write(value, encoder);
+        encoder.flush();
+      }
+
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new DataException("Error serializing message to format Avro", e);
+    }
+  }
+}

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatter.java
@@ -17,6 +17,7 @@
 package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
 
 import io.confluent.connect.avro.AvroData;
+import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.serializers.NonRecordContainer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -31,6 +32,8 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AvroFormatter implements RecordFormatter {
 
@@ -38,7 +41,11 @@ public class AvroFormatter implements RecordFormatter {
   private final EncoderFactory encoderFactory;
 
   public AvroFormatter() {
-    avroData = new AvroData(10);
+    Map<String, Object> avroDataConfigMap  = new HashMap<String, Object>() {{
+      put(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, true);
+      put(AvroDataConfig.SCHEMAS_CACHE_SIZE_CONFIG, 10);
+    }};
+    avroData = new AvroData(new AvroDataConfig(avroDataConfigMap));
     encoderFactory = EncoderFactory.get();
   }
 

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatter.java
@@ -1,12 +1,12 @@
 /**
  * Copyright © 2017 Kyumars Sheykh Esmaili (kyumarss@gmail.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,10 +41,10 @@ public class AvroFormatter implements RecordFormatter {
   private final EncoderFactory encoderFactory;
 
   public AvroFormatter() {
-    Map<String, Object> avroDataConfigMap  = new HashMap<String, Object>() {{
-      put(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, true);
-      put(AvroDataConfig.SCHEMAS_CACHE_SIZE_CONFIG, 10);
-    }};
+    Map<String, Object> avroDataConfigMap = new HashMap<String, Object>() { {
+        put(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, true);
+        put(AvroDataConfig.SCHEMAS_CACHE_SIZE_CONFIG, 10);
+      } };
     avroData = new AvroData(new AvroDataConfig(avroDataConfigMap));
     encoderFactory = EncoderFactory.get();
   }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/BytesRecordFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/BytesRecordFormatter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2017 Kyumars Sheykh Esmaili (kyumarss@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class BytesRecordFormatter implements RecordFormatter {
+
+  private final ByteArrayConverter converter;
+
+  public BytesRecordFormatter() {
+    converter = new ByteArrayConverter();
+  }
+
+  @Override
+  public byte[] format(SinkRecord record) {
+    return converter.fromConnectData(
+          record.topic(),
+          record.valueSchema(),
+          record.value());
+  }
+}

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/JsonRecordFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/JsonRecordFormatter.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright © 2017 Kyumars Sheykh Esmaili (kyumarss@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JsonRecordFormatter implements RecordFormatter {
+
+  private final ObjectMapper mapper;
+  private final JsonConverter converter;
+
+  public JsonRecordFormatter() {
+    this.mapper = new ObjectMapper();
+    mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    mapper.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
+    mapper.registerModule(new JavaTimeModule());
+    converter = new JsonConverter();
+    Map<String, Object> converterConfig = new HashMap<>();
+    converterConfig.put("schemas.enable", "false");
+    converterConfig.put("schemas.cache.size", "10");
+    this.converter.configure(converterConfig, false);
+  }
+
+  @Override
+  public byte[] format(SinkRecord record) {
+    try {
+      Object value = record.value();
+      if (value instanceof Struct) {
+        return converter.fromConnectData(
+                record.topic(),
+                record.valueSchema(),
+                value
+          );
+      } else {
+        return mapper.writeValueAsBytes(value);
+      }
+    } catch (IOException e) {
+      throw new ConnectException(e);
+    }
+  }
+}

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/RecordFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/RecordFormatter.java
@@ -28,7 +28,9 @@ public interface RecordFormatter {
       return new BytesRecordFormatter();
     } else if ("json".equals(type)) {
       return new JsonRecordFormatter();
+    } else if ("avro".equals(type)) {
+      return new AvroFormatter();
     }
-    throw new ConnectException("The provided format type is not one of 'bytes' or 'json', but: " + type);
+    throw new ConnectException("The provided format type is not one of 'bytes', 'json' or 'avro', but: " + type);
   }
 }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/RecordFormatter.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/RecordFormatter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2017 Kyumars Sheykh Esmaili (kyumarss@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public interface RecordFormatter {
+
+  byte[] format(SinkRecord sinkRecord);
+
+  static RecordFormatter getInstance(String type) {
+    if ("bytes".equals(type)) {
+      return new BytesRecordFormatter();
+    } else if ("json".equals(type)) {
+      return new JsonRecordFormatter();
+    }
+    throw new ConnectException("The provided format type is not one of 'bytes' or 'json', but: " + type);
+  }
+}

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/ConnectConsumer.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/ConnectConsumer.java
@@ -71,9 +71,6 @@ class ConnectConsumer implements Consumer {
   public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties basicProperties, byte[] bytes) {
     log.trace("handleDelivery({})", consumerTag);
 
-    log.info(envelope.toString());
-    log.info(basicProperties.toString());
-
     SourceRecord sourceRecord = this.sourceRecordBuilder.sourceRecord(queue, consumerTag, envelope, basicProperties, bytes);
     this.records.add(sourceRecord);
   }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/ConnectConsumer.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/ConnectConsumer.java
@@ -32,10 +32,14 @@ class ConnectConsumer implements Consumer {
   private static final Logger log = LoggerFactory.getLogger(ConnectConsumer.class);
   private final SourceRecordConcurrentLinkedDeque records;
   private final SourceRecordBuilder sourceRecordBuilder;
+  private final String queue;
 
-  ConnectConsumer(SourceRecordConcurrentLinkedDeque records, RabbitMQSourceConnectorConfig config) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+  ConnectConsumer(SourceRecordConcurrentLinkedDeque records,
+                  RabbitMQSourceConnectorConfig config,
+                  String queue) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
     this.records = records;
     this.sourceRecordBuilder = new SourceRecordBuilder(config);
+    this.queue = queue;
   }
 
   @Override
@@ -67,7 +71,10 @@ class ConnectConsumer implements Consumer {
   public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties basicProperties, byte[] bytes) {
     log.trace("handleDelivery({})", consumerTag);
 
-    SourceRecord sourceRecord = this.sourceRecordBuilder.sourceRecord(consumerTag, envelope, basicProperties, bytes);
+    log.info(envelope.toString());
+    log.info(basicProperties.toString());
+
+    SourceRecord sourceRecord = this.sourceRecordBuilder.sourceRecord(queue, consumerTag, envelope, basicProperties, bytes);
     this.records.add(sourceRecord);
   }
 }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnector.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnector.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class RabbitMQSourceConnector extends SourceConnector {
 
   private Map<String, String> settings;
+  private RabbitMQSourceConnectorConfig config;
 
   @Override
   public String version() {
@@ -38,6 +39,7 @@ public class RabbitMQSourceConnector extends SourceConnector {
   @Override
   public void start(Map<String, String> settings) {
     this.settings = settings;
+    this.config = new RabbitMQSourceConnectorConfig(settings);
   }
 
   @Override

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfig.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfig.java
@@ -49,10 +49,9 @@ public class RabbitMQSourceConnectorConfig extends CommonRabbitMQConnectorConfig
       "com.github.themeetgroup.kafka.connect.rabbitmq.source.data.MessageConverter";
 
   public static final String QUEUE_TOPIC_MAPPING_CONF = "rabbitmq.queue.topic.mapping";
-  public static final String QUEUE_TOPIC_MAPPING_DOC = "A comma separated list containing a mapping between a RabbitMQ queue and a Kafka topic. " +
-      "This setting is an alternative for the 'rabbitmq.queue' and 'kafka.topic' setting. This setting is mutual exclusive of the 'rabbitmq.queue' and 'kafka.topic' combination. " +
-      "When both settings are present. This combination of the original config will be used. " +
-      "example of mapping config: 'queue1:topic1,queue2:topic2'";
+  public static final String QUEUE_TOPIC_MAPPING_DOC = "A list containing a mapping between a RabbitMQ queue and a Kafka topic.\n" +
+      " This setting is an alternative for the 'rabbitmq.queue' and 'kafka.topic' setting.\n" +
+      "  When both settings are present. The 'rabbitmq.queue' and 'kafka.topic' will be used. Example of mapping config: 'queue1:topic1,queue2:topic2'";
 
   public final int prefetchCount;
   public final boolean prefetchGlobal;

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfig.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfig.java
@@ -17,9 +17,15 @@ package com.github.themeetgroup.kafka.connect.rabbitmq.source;
 
 import com.github.themeetgroup.kafka.connect.rabbitmq.CommonRabbitMQConnectorConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.errors.ConnectException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
 
 public class RabbitMQSourceConnectorConfig extends CommonRabbitMQConnectorConfig {
 
@@ -42,28 +48,48 @@ public class RabbitMQSourceConnectorConfig extends CommonRabbitMQConnectorConfig
   public static final String MESSAGE_CONVERTER_CLASSNAME_DOC = "Converter to compose the Kafka message. Optional, defaults to " +
       "com.github.themeetgroup.kafka.connect.rabbitmq.source.data.MessageConverter";
 
-  public final String kafkaTopic;
-  public final List<String> queues;
+  public static final String QUEUE_TOPIC_MAPPING_CONF = "rabbitmq.queue.topic.mapping";
+  public static final String QUEUE_TOPIC_MAPPING_DOC = "A comma separated list containing a mapping between a RabbitMQ queue and a Kafka topic. " +
+      "This setting is an alternative for the 'rabbitmq.queue' and 'kafka.topic' setting. This setting is mutual exclusive of the 'rabbitmq.queue' and 'kafka.topic' combination. " +
+      "When both settings are present. This combination of the original config will be used. " +
+      "example of mapping config: 'queue1:topic1,queue2:topic2'";
+
   public final int prefetchCount;
   public final boolean prefetchGlobal;
   public final String messageConverter;
+  public final Map<String, String> queueToTopicMap;
 
   public RabbitMQSourceConnectorConfig(Map<String, String> settings) {
     super(config(), settings);
 
-    this.kafkaTopic = this.getString(TOPIC_CONF);
-    this.queues = this.getList(QUEUE_CONF);
     this.prefetchCount = this.getInt(PREFETCH_COUNT_CONF);
     this.prefetchGlobal = this.getBoolean(PREFETCH_GLOBAL_CONF);
     this.messageConverter = this.getString(MESSAGE_CONVERTER_CLASSNAME_CONF);
+
+    String topic = this.getString(TOPIC_CONF);
+    List<String> queues = this.getList(QUEUE_CONF);
+    List<String> queueTopicMappingList = this.getList(QUEUE_TOPIC_MAPPING_CONF);
+
+    if (!queues.isEmpty() && !topic.isEmpty()) {
+      queueToTopicMap = queues.stream()
+          .collect(Collectors.toMap(x -> x, x -> topic));
+    } else if (!queueTopicMappingList.isEmpty()) {
+      queueToTopicMap = queueTopicMappingList.stream()
+          .map(x -> x.split(":"))
+          .collect(toMap(x -> x[0], x -> x[1]));
+    } else {
+      throw new ConnectException("No valid queue / topic configuration has been found. Either use the combination of " +
+          "" + TOPIC_CONF + " and " + QUEUE_CONF + " or use the " + QUEUE_TOPIC_MAPPING_CONF + " setting.");
+    }
   }
 
   public static ConfigDef config() {
     return CommonRabbitMQConnectorConfig.config()
-        .define(TOPIC_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TOPIC_DOC)
+        .define(TOPIC_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.HIGH, TOPIC_DOC)
         .define(PREFETCH_COUNT_CONF, ConfigDef.Type.INT, 0, ConfigDef.Importance.MEDIUM, PREFETCH_COUNT_DOC)
         .define(PREFETCH_GLOBAL_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, PREFETCH_GLOBAL_DOC)
-        .define(QUEUE_CONF, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH, QUEUE_DOC)
-        .define(MESSAGE_CONVERTER_CLASSNAME_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM, MESSAGE_CONVERTER_CLASSNAME_DOC);
+        .define(QUEUE_CONF, ConfigDef.Type.LIST, new ArrayList<>(), ConfigDef.Importance.HIGH, QUEUE_DOC)
+        .define(MESSAGE_CONVERTER_CLASSNAME_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM, MESSAGE_CONVERTER_CLASSNAME_DOC)
+        .define(QUEUE_TOPIC_MAPPING_CONF, ConfigDef.Type.LIST, new ArrayList<>(), ConfigDef.Importance.HIGH, QUEUE_TOPIC_MAPPING_DOC);
   }
 }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfig.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfig.java
@@ -89,7 +89,7 @@ public class RabbitMQSourceConnectorConfig extends CommonRabbitMQConnectorConfig
         .define(PREFETCH_COUNT_CONF, ConfigDef.Type.INT, 0, ConfigDef.Importance.MEDIUM, PREFETCH_COUNT_DOC)
         .define(PREFETCH_GLOBAL_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, PREFETCH_GLOBAL_DOC)
         .define(QUEUE_CONF, ConfigDef.Type.LIST, new ArrayList<>(), ConfigDef.Importance.HIGH, QUEUE_DOC)
-        .define(MESSAGE_CONVERTER_CLASSNAME_CONF, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM, MESSAGE_CONVERTER_CLASSNAME_DOC)
+        .define(MESSAGE_CONVERTER_CLASSNAME_CONF, ConfigDef.Type.STRING, null, ConfigDef.Importance.MEDIUM, MESSAGE_CONVERTER_CLASSNAME_DOC)
         .define(QUEUE_TOPIC_MAPPING_CONF, ConfigDef.Type.LIST, new ArrayList<>(), ConfigDef.Importance.HIGH, QUEUE_TOPIC_MAPPING_DOC);
   }
 }

--- a/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceTask.java
+++ b/src/main/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceTask.java
@@ -20,6 +20,8 @@ import com.github.jcustenborder.kafka.connect.utils.data.SourceRecordConcurrentL
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -29,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatterTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatterTest.java
@@ -8,6 +8,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.util.Utf8;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.connect.data.Struct;

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatterTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/AvroFormatterTest.java
@@ -1,0 +1,78 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.util.Utf8;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.createSinkRecord;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.paymentSchema;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.paymentValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AvroFormatterTest {
+
+  private final RecordFormatter avroRecordFormatter = new AvroFormatter();
+  private final DecoderFactory decoderFactory = DecoderFactory.get();
+  private final KafkaAvroDeserializer kafkaAvroDeserializer = new KafkaAvroDeserializer(new MockSchemaRegistryClient());
+
+  private Schema schema;
+
+  @BeforeEach
+  void setUp() throws IOException, URISyntaxException {
+    URL resource = this.getClass().getClassLoader().getResource("payment.avsc");
+    schema = new Schema.Parser().parse(new File(resource.toURI()));
+  }
+
+  @Test
+  void givenAStruct_whenFormattingWithAvroRecordFormatter_expectStructToJson() throws IOException {
+    Struct payment = paymentValue(1, true, "testSender");
+    SinkRecord sinkRecord = createSinkRecord(paymentSchema(), payment);
+
+    byte[] output = avroRecordFormatter.format(sinkRecord);
+
+    GenericRecord record = toGenericRecord(schema, output);
+    assertEquals(1, record.get("id"));
+    assertEquals(true, record.get("isCashPayment"));
+    assertEquals(new Utf8("testSender"), record.get("sender"));
+  }
+
+  // The "avro" formatter is serializing data in NON-confluent avro, meaning the first bytes do not contain the schema id
+  // see: https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format
+  // If you want confluent avro bytes using the RabbitMQ sink connector
+  // you can use the "org.apache.kafka.connect.converters.ByteArrayConverter" converter
+  // after putting confluent avro serialized data on your topic
+  @Test
+  void validateExceptionIsThrown_whenTryingToDeserializeOutputWithKafkaAvroDeserializer() {
+    Struct payment = paymentValue(1, true, "testSender");
+    SinkRecord sinkRecord = createSinkRecord(paymentSchema(), payment);
+
+    byte[] output = avroRecordFormatter.format(sinkRecord);
+
+    assertThrows(SerializationException.class, () -> kafkaAvroDeserializer.deserialize("test", output));
+  }
+
+  private GenericRecord toGenericRecord(Schema schema, byte[] avroBytes) throws IOException {
+    DatumReader<GenericRecord> reader = new GenericDatumReader<>(schema);
+    ByteArrayInputStream stream = new ByteArrayInputStream(avroBytes);
+    BinaryDecoder binaryDecoder = decoderFactory.binaryDecoder(stream, null);
+    return reader.read(null, binaryDecoder);
+  }
+}

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/BytesRecordFormatterTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/BytesRecordFormatterTest.java
@@ -31,7 +31,7 @@ class BytesRecordFormatterTest {
   // This is also the default behaviour when not specifying a formatter
   @Test
   void givenAStruct_whenFormattingWithBytesRecordFormatter_expectDataException() {
-    Struct payment = paymentValue(1, true, "testSender");
+    Struct payment = paymentValue(1, true, Currency.EURO, "testSender");
     SinkRecord record = createSinkRecord(TestData.paymentSchema(), payment);
 
     assertThrows(DataException.class, () -> bytesRecordFormatter.format(record));

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/BytesRecordFormatterTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/BytesRecordFormatterTest.java
@@ -1,0 +1,39 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.createSinkRecord;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.paymentValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BytesRecordFormatterTest {
+
+  private final RecordFormatter bytesRecordFormatter = new BytesRecordFormatter();
+
+  @Test
+  void givenABytesSchemaAndValue_expectCorrectFormat() {
+    byte[] testString = "test".getBytes(StandardCharsets.UTF_8);
+    SinkRecord record = createSinkRecord(Schema.BYTES_SCHEMA, testString);
+
+    byte[] output = bytesRecordFormatter.format(record);
+
+    assertEquals(testString, output);
+  }
+
+  // When using the BytesFormatter, the "org.apache.kafka.connect.converters.ByteArrayConverter" must be used as value converter
+  // This is also the default behaviour when not specifying a formatter
+  @Test
+  void givenAStruct_whenFormattingWithBytesRecordFormatter_expectDataException() {
+    Struct payment = paymentValue(1, true, "testSender");
+    SinkRecord record = createSinkRecord(TestData.paymentSchema(), payment);
+
+    assertThrows(DataException.class, () -> bytesRecordFormatter.format(record));
+  }
+}

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/JsonRecordFormatterTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/JsonRecordFormatterTest.java
@@ -54,17 +54,18 @@ class JsonRecordFormatterTest {
 
   @Test
   void givenAStruct_whenFormattingWithJsonRecordFormatter_expectStructToJson() throws IOException {
-    Struct payment = paymentValue(1, true, "testSender");
+    Struct payment = paymentValue(1, true, Currency.EURO, "testSender");
     SinkRecord sinkRecord = createSinkRecord(TestData.paymentSchema(), payment);
 
     byte[] output = jsonRecordFormatter.format(sinkRecord);
 
     Map map = objectMapper.readValue(output, Map.class);
-    assertEquals(4, map.size());
+    assertEquals(5, map.size());
     assertEquals(1, map.get("id"));
     assertEquals(true, map.get("isCashPayment"));
     assertEquals("testSender", map.get("sender"));
     assertNull(map.get("comment"));
+    assertEquals("EURO", map.get("currency"));
   }
 
   @Test

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/JsonRecordFormatterTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/JsonRecordFormatterTest.java
@@ -1,0 +1,84 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.createSinkRecord;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.TestData.paymentValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class JsonRecordFormatterTest {
+
+  private final RecordFormatter jsonRecordFormatter = new JsonRecordFormatter();
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    objectMapper.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
+    objectMapper.registerModule(new JavaTimeModule());
+  }
+
+  @Test
+  void givenAStringSchemaAndValue_whenFormattingWithJsonRecordFormatter_expectQuotedString() {
+    String value = "test";
+    SinkRecord sinkRecord = TestData.createSinkRecord(Schema.STRING_SCHEMA, value);
+
+    byte[] output = jsonRecordFormatter.format(sinkRecord);
+
+    assertEquals("\"test\"", new String(output, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void givenAnIntSchemaAndValue_whenFormattingWithJsonRecordFormatter_expectQuotedInt() {
+    int value = 44;
+    SinkRecord sinkRecord = TestData.createSinkRecord(Schema.INT32_SCHEMA, value);
+
+    byte[] output = jsonRecordFormatter.format(sinkRecord);
+
+    assertEquals("44", new String(output, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void givenAStruct_whenFormattingWithJsonRecordFormatter_expectStructToJson() throws IOException {
+    Struct payment = paymentValue(1, true, "testSender");
+    SinkRecord sinkRecord = createSinkRecord(TestData.paymentSchema(), payment);
+
+    byte[] output = jsonRecordFormatter.format(sinkRecord);
+
+    Map map = objectMapper.readValue(output, Map.class);
+    assertEquals(4, map.size());
+    assertEquals(1, map.get("id"));
+    assertEquals(true, map.get("isCashPayment"));
+    assertEquals("testSender", map.get("sender"));
+    assertNull(map.get("comment"));
+  }
+
+  @Test
+  void givenASchemalessValue_whenFormattingWithJsonRecordFormatter_expectMapToJson() throws IOException {
+    Map<String, Object> schemalessValue = new HashMap<>();
+    schemalessValue.put("id", 1);
+    schemalessValue.put("sender", "testSender");
+    SinkRecord sinkRecord = createSinkRecord(null, schemalessValue);
+
+    byte[] output = jsonRecordFormatter.format(sinkRecord);
+
+    Map map = objectMapper.readValue(output, Map.class);
+    assertEquals(2, map.size());
+    assertEquals(1, map.get("id"));
+    assertEquals("testSender", map.get("sender"));
+  }
+}

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/PlainAvroDeserializer.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/PlainAvroDeserializer.java
@@ -1,0 +1,55 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import org.apache.avro.Schema;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class PlainAvroDeserializer<T extends SpecificRecord> implements Deserializer<T> {
+
+  static {
+    SpecificData.get().addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    SpecificData.get().addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    SpecificData.get().addLogicalTypeConversion(new TimeConversions.DateConversion());
+
+    GenericData.get().addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+    GenericData.get().addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    GenericData.get().addLogicalTypeConversion(new TimeConversions.DateConversion());
+  }
+
+  private final DecoderFactory decoderFactory = DecoderFactory.get();
+  private final DatumReader<T> datumReader;
+
+  public PlainAvroDeserializer(Class<T> cls) {
+    this(SpecificData.get().getSchema(cls));
+  }
+
+  public PlainAvroDeserializer(Schema schema) {
+    datumReader = new SpecificDatumReader<>(schema);
+  }
+
+  @Override
+  public T deserialize(String topic, byte[] data) {
+    try {
+      if (data == null) {
+        return null;
+      }
+
+      try (ByteArrayInputStream stream = new ByteArrayInputStream(data)) {
+        BinaryDecoder binaryDecoder = decoderFactory.binaryDecoder(stream, null);
+        return datumReader.read(null, binaryDecoder);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/TestData.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/TestData.java
@@ -1,0 +1,36 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.sink.format;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class TestData {
+
+  public static Schema paymentSchema() {
+    return SchemaBuilder.struct()
+        .name("com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.Payment")
+        .doc("Payment schema used in unit tests")
+        .field("id", SchemaBuilder.int32().build())
+        .field("isCashPayment", SchemaBuilder.bool().build())
+        .field("sender", SchemaBuilder.string().build())
+        .field("comment", SchemaBuilder.string().optional().build())
+        .build();
+  }
+
+  public static Struct paymentValue(int id, boolean isCashPayment, String sender) {
+    return paymentValue(id, isCashPayment, sender, null);
+  }
+
+  public static Struct paymentValue(int id, boolean isCashPayment, String sender, String comment) {
+    return new Struct(paymentSchema())
+        .put("id", id)
+        .put("isCashPayment", isCashPayment)
+        .put("sender", sender)
+        .put("comment", comment);
+  }
+
+  public static SinkRecord createSinkRecord(Schema valueSchema, Object value) {
+    return new SinkRecord("test", 0, null, null, valueSchema, value, 0);
+  }
+}

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/TestData.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/sink/format/TestData.java
@@ -13,19 +13,31 @@ public class TestData {
         .doc("Payment schema used in unit tests")
         .field("id", SchemaBuilder.int32().build())
         .field("isCashPayment", SchemaBuilder.bool().build())
+        .field("currency", SchemaBuilder.string()
+            .parameter(
+                "io.confluent.connect.avro.Enum",
+                "com.github.themeetgroup.kafka.connect.rabbitmq.sink.format.Currency")
+            .parameter(
+                "io.confluent.connect.avro.Enum.EURO",
+                "EURO")
+            .parameter(
+                "io.confluent.connect.avro.Enum.DOLLAR",
+                "DOLLAR")
+            .build())
         .field("sender", SchemaBuilder.string().build())
         .field("comment", SchemaBuilder.string().optional().build())
         .build();
   }
 
-  public static Struct paymentValue(int id, boolean isCashPayment, String sender) {
-    return paymentValue(id, isCashPayment, sender, null);
+  public static Struct paymentValue(int id, boolean isCashPayment, Currency currency, String sender) {
+    return paymentValue(id, isCashPayment, currency, sender, null);
   }
 
-  public static Struct paymentValue(int id, boolean isCashPayment, String sender, String comment) {
+  public static Struct paymentValue(int id, boolean isCashPayment, Currency currency, String sender, String comment) {
     return new Struct(paymentSchema())
         .put("id", id)
         .put("isCashPayment", isCashPayment)
+        .put("currency", currency.toString())
         .put("sender", sender)
         .put("comment", comment);
   }

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfigTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorConfigTest.java
@@ -1,0 +1,53 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.source;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnectorConfig.QUEUE_CONF;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnectorConfig.QUEUE_TOPIC_MAPPING_CONF;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnectorConfig.TOPIC_CONF;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RabbitMQSourceConnectorConfigTest {
+
+    @Test
+    void givenNoTopicAndQueueAndQueueToTopicConfig_whenCreatingConfig_expectConnectException() {
+        Map<String, String> settings = new HashMap<>();
+
+        assertThrows(ConnectException.class, () -> new RabbitMQSourceConnectorConfig(settings));
+    }
+
+    @Test
+    void givenTopicAndQueuesCombination_whenCreatingConfig_expectEveryQueueMappedToSameTopic() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(TOPIC_CONF, "test_topic");
+        settings.put(QUEUE_CONF, "queue1,queue2,queue3");
+
+        RabbitMQSourceConnectorConfig config = new RabbitMQSourceConnectorConfig(settings);
+
+        Map<String, String> queueToTopicMap = config.queueToTopicMap;
+        assertEquals(3, queueToTopicMap.size());
+        assertEquals("test_topic", queueToTopicMap.get("queue1"));
+        assertEquals("test_topic", queueToTopicMap.get("queue2"));
+        assertEquals("test_topic", queueToTopicMap.get("queue2"));
+    }
+
+    @Test
+    void givenOnlyTopicToQueueMapping_whenCreatingConfig_expectTopicCorrectlyMapped() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(QUEUE_TOPIC_MAPPING_CONF, "queue1:topic1,queue2:topic2,queue3:topic2");
+
+        RabbitMQSourceConnectorConfig config = new RabbitMQSourceConnectorConfig(settings);
+
+        Map<String, String> queueToTopicMap = config.queueToTopicMap;
+        assertEquals(3, queueToTopicMap.size());
+        assertEquals("topic1", queueToTopicMap.get("queue1"));
+        assertEquals("topic2", queueToTopicMap.get("queue2"));
+        assertEquals("topic2", queueToTopicMap.get("queue3"));
+    }
+}

--- a/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorTest.java
+++ b/src/test/java/com/github/themeetgroup/kafka/connect/rabbitmq/source/RabbitMQSourceConnectorTest.java
@@ -1,0 +1,50 @@
+package com.github.themeetgroup.kafka.connect.rabbitmq.source;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnectorConfig.QUEUE_CONF;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnectorConfig.QUEUE_TOPIC_MAPPING_CONF;
+import static com.github.themeetgroup.kafka.connect.rabbitmq.source.RabbitMQSourceConnectorConfig.TOPIC_CONF;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RabbitMQSourceConnectorTest {
+
+    private RabbitMQSourceConnector connector;
+
+    @BeforeEach
+    void setUp() {
+        connector = new RabbitMQSourceConnector();
+    }
+
+    @Test
+    void givenNormalTopicAndQueueConfig_whenCreatingTaskConfig_expectSameConfigForEveryTask() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(TOPIC_CONF, "test_topic");
+        settings.put(QUEUE_CONF, "queue1,queue2,queue3");
+
+        connector.start(settings);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(2);
+
+        assertEquals(2, taskConfigs.size());
+        assertEquals(taskConfigs.get(0), taskConfigs.get(1));
+    }
+
+    @Test
+    void givenQueueToTopicMappingConfig_whenCreatingTaskConfig_expectConfigSplitUpPerTask() {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(QUEUE_TOPIC_MAPPING_CONF, "queue1:topic1,queue2:topic2,queue3:topic2");
+
+        connector.start(settings);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(3);
+
+        assertEquals(3, taskConfigs.size());
+        assertEquals("queue1:topic1", taskConfigs.get(0).get(QUEUE_TOPIC_MAPPING_CONF));
+        assertEquals("queue2:topic2", taskConfigs.get(1).get(QUEUE_TOPIC_MAPPING_CONF));
+        assertEquals("queue3:topic2", taskConfigs.get(2).get(QUEUE_TOPIC_MAPPING_CONF));
+    }
+}

--- a/src/test/resources/payment.avsc
+++ b/src/test/resources/payment.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "name": "Payment",
+    "namespace": "com.github.themeetgroup.kafka.connect.rabbitmq.sink.format",
+    "fields": [
+        {"name": "id", "type": "int"},
+        {"name": "isCashPayment", "type": "boolean"},
+        {"name": "sender", "type": "string"},
+        {"name": "comment", "type": ["null", "string"], "default": null}
+    ]
+}

--- a/src/test/resources/payment.avsc
+++ b/src/test/resources/payment.avsc
@@ -5,6 +5,7 @@
     "fields": [
         {"name": "id", "type": "int"},
         {"name": "isCashPayment", "type": "boolean"},
+        {"name": "currency", "type": { "type": "enum", "name": "Currency", "symbols" : ["EURO","DOLLAR"]}},
         {"name": "sender", "type": "string"},
         {"name": "comment", "type": ["null", "string"], "default": null}
     ]


### PR DESCRIPTION
Add option to add a formatter when writing data to RabbitMQ:

- Added the sink connector option "rabbitmq.format"
- Before you had to use the ByteArrayConverter to use the RabbitMQ sink connector. Now you can use a formatter to put another format on your queue(s). Currently an implementation has been written for json and (non confluent) avro.
- This change is backwards compatible, when no formatter is provided, the default value "bytes" is used. This requires you to use the "org.apache.kafka.connect.converters.ByteArrayConverter" converter like before